### PR TITLE
🔧 refactor(migrations): enhance nullable checks for amount_tva and co…

### DIFF
--- a/src/migrations/1734234567890-UpdateVirementSepaFields.ts
+++ b/src/migrations/1734234567890-UpdateVirementSepaFields.ts
@@ -6,26 +6,54 @@ export class UpdateVirementSepaFields1734234567890
   name = 'UpdateVirementSepaFields1734234567890';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    // Modification de amount_tva pour être nullable
-    await queryRunner.query(
-      `ALTER TABLE "virement_sepa" ALTER COLUMN "amount_tva" DROP NOT NULL`,
+    // Vérification et modification de amount_tva pour être nullable
+    const amountTvaResult = await queryRunner.query(
+      `SELECT is_nullable FROM information_schema.columns 
+       WHERE table_name = 'virement_sepa' AND column_name = 'amount_tva'`,
     );
 
-    // Modification de communication pour ne plus être nullable
-    await queryRunner.query(
-      `ALTER TABLE "virement_sepa" ALTER COLUMN "communication" SET NOT NULL`,
+    if (amountTvaResult[0]?.is_nullable === 'NO') {
+      await queryRunner.query(
+        `ALTER TABLE "virement_sepa" ALTER COLUMN "amount_tva" DROP NOT NULL`,
+      );
+    }
+
+    // Vérification et modification de communication pour ne plus être nullable
+    const communicationResult = await queryRunner.query(
+      `SELECT is_nullable FROM information_schema.columns 
+       WHERE table_name = 'virement_sepa' AND column_name = 'communication'`,
     );
+
+    if (communicationResult[0]?.is_nullable === 'YES') {
+      await queryRunner.query(
+        `ALTER TABLE "virement_sepa" ALTER COLUMN "communication" SET NOT NULL`,
+      );
+    }
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    // Retour en arrière pour amount_tva
-    await queryRunner.query(
-      `ALTER TABLE "virement_sepa" ALTER COLUMN "amount_tva" SET NOT NULL`,
+    // Vérification et retour en arrière pour amount_tva
+    const amountTvaResult = await queryRunner.query(
+      `SELECT is_nullable FROM information_schema.columns 
+       WHERE table_name = 'virement_sepa' AND column_name = 'amount_tva'`,
     );
 
-    // Retour en arrière pour communication
-    await queryRunner.query(
-      `ALTER TABLE "virement_sepa" ALTER COLUMN "communication" DROP NOT NULL`,
+    if (amountTvaResult[0]?.is_nullable === 'YES') {
+      await queryRunner.query(
+        `ALTER TABLE "virement_sepa" ALTER COLUMN "amount_tva" SET NOT NULL`,
+      );
+    }
+
+    // Vérification et retour en arrière pour communication
+    const communicationResult = await queryRunner.query(
+      `SELECT is_nullable FROM information_schema.columns 
+       WHERE table_name = 'virement_sepa' AND column_name = 'communication'`,
     );
+
+    if (communicationResult[0]?.is_nullable === 'NO') {
+      await queryRunner.query(
+        `ALTER TABLE "virement_sepa" ALTER COLUMN "communication" DROP NOT NULL`,
+      );
+    }
   }
 }


### PR DESCRIPTION
…mmunication fields

- Updated migration logic to check the current nullable state of 'amount_tva' and 'communication' fields in the 'virement_sepa' table before applying changes.
- Ensured 'amount_tva' is set to nullable if it is currently not, and 'communication' is set to not nullable if it is currently nullable, improving migration reliability.