### PR TITLE
🔧 refactor(migrations): clean up CreateNotificationTable migration

### DIFF
--- a/src/migrations/1710859200000-CreateNotificationTable.ts
+++ b/src/migrations/1710859200000-CreateNotificationTable.ts
@@ -4,7 +4,6 @@ export class CreateNotificationTable1710859200000
   implements MigrationInterface
 {
   name = 'CreateNotificationTable1710859200000';
-
   public async up(queryRunner: QueryRunner): Promise<void> {
     // Vérifier si la table existe déjà
     const tableExists = await queryRunner.hasTable('notification');


### PR DESCRIPTION
- Removed unnecessary blank line in the CreateNotificationTable migration file for improved code clarity.