### PR TITLE
🔧 fix(virement-sepa): correct account lookup logic in user secondary …

### DIFF
--- a/src/virement-sepa/virement-sepa.service.ts
+++ b/src/virement-sepa/virement-sepa.service.ts
@@ -55,7 +55,7 @@ export class VirementSepaService {
 
       if (user.role !== 'ADMIN') {
         accountFinded = user.userSecondaryAccounts?.find(
-          (account) => account.secondary_account_id === +params.id,
+          (account) => account.group_account.id === +params.id,
         );
 
         user.userSecondaryAccounts?.forEach((account) => {


### PR DESCRIPTION
…accounts

- Updated the account lookup logic in VirementSepaService to match accounts by group_account.id instead of secondary_account_id.
- This change ensures accurate retrieval of user secondary accounts based on the provided parameters.