### PR TITLE
🔧 refactor(docker, cache): remove Redis and simplify cache configuration

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   backend:
     image: dimagin/sonar-back:latest
@@ -43,35 +41,9 @@ services:
       start_interval: 5s
       start_period: 30s
 
-  redis:
-    container_name: redis
-    image: redis:latest
-    ports:
-      - '6379:6379'
-    volumes:
-      - ./data/redis:/data
-    networks:
-      - postgres
-
-  pgadmin:
-    container_name: pgadmin
-    image: dpage/pgadmin4
-    ports:
-      - '5050:80'
-    volumes:
-      - ./data/pgadmin:/root/.pgadmin
-    env_file:
-      - .env
-    networks:
-      - postgres
-
 networks:
   sonar-network:
-    driver: bridge
-  postgres:
     driver: bridge
 
 volumes:
   sonar-db-data:
-  redis:
-  pgadmin:

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "helmet": "^8.0.0",
         "jspdf": "^2.5.2",
         "jspdf-autotable": "^3.8.3",
+        "keyv": "^5.2.3",
         "multer": "^1.4.5-lts.1",
         "mysql2": "^3.11.0",
         "nestjs-googledrive-upload": "^2.0.0",
@@ -6044,15 +6045,6 @@
         "node": ">= 16.18.0"
       }
     },
-    "node_modules/cache-manager/node_modules/keyv": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.2.3.tgz",
-      "integrity": "sha512-AGKecUfzrowabUv0bH1RIR5Vf7w+l4S3xtQAypKaUpTdIR1EbrAcTxHCrpo9Q+IWeUlFE2palRtgIQcgm+PQJw==",
-      "license": "MIT",
-      "dependencies": {
-        "@keyv/serialize": "^1.0.2"
-      }
-    },
     "node_modules/call-bind": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
@@ -7945,6 +7937,16 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flat-cache/node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/flatted": {
@@ -10088,13 +10090,12 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.2.3.tgz",
+      "integrity": "sha512-AGKecUfzrowabUv0bH1RIR5Vf7w+l4S3xtQAypKaUpTdIR1EbrAcTxHCrpo9Q+IWeUlFE2palRtgIQcgm+PQJw==",
       "license": "MIT",
       "dependencies": {
-        "json-buffer": "3.0.1"
+        "@keyv/serialize": "^1.0.2"
       }
     },
     "node_modules/kleur": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "helmet": "^8.0.0",
     "jspdf": "^2.5.2",
     "jspdf-autotable": "^3.8.3",
+    "keyv": "^5.2.3",
     "multer": "^1.4.5-lts.1",
     "mysql2": "^3.11.0",
     "nestjs-googledrive-upload": "^2.0.0",

--- a/src/config/cache.config.ts
+++ b/src/config/cache.config.ts
@@ -1,14 +1,7 @@
 import { CacheModuleOptions } from '@nestjs/cache-manager';
-import { RedisStore } from 'cache-manager-redis-store';
-import { redisStore } from 'cache-manager-redis-store';
 
-export const cacheConfig = {
+export const cacheConfig: CacheModuleOptions = {
   isGlobal: true,
-  store: redisStore,
-  socket: {
-    host: process.env.REDIS_HOST || 'localhost',
-    port: parseInt(process.env.REDIS_PORT) || 6379,
-  },
   ttl: 300, // 5 minutes en secondes
-  max: 100,
-} as CacheModuleOptions;
+  max: 100, // nombre maximum d'éléments en cache
+};


### PR DESCRIPTION
- Removed Redis and pgAdmin services from docker-compose.yaml
- Simplified cache configuration by removing Redis-specific settings
- Updated package.json and package-lock.json to manage Keyv dependency
- Refactored cache.config.ts to use default in-memory caching strategy