### PR TITLE
✨ feat(notification): Renommer le contrôleur de notifications et ajou…

### DIFF
--- a/src/notification/notification.controller.ts
+++ b/src/notification/notification.controller.ts
@@ -9,7 +9,7 @@ import {
 } from '@nestjs/common';
 import { NotificationService } from './notification.service';
 
-@Controller('notifications')
+@Controller('alert-notifications')
 export class NotificationController {
   constructor(private readonly notificationService: NotificationService) {}
 

--- a/src/push-notification/push-notification.controller.ts
+++ b/src/push-notification/push-notification.controller.ts
@@ -77,4 +77,22 @@ export class PushNotificationController {
     await this.pushNotificationService.forceUnsubscribeUser(+userId);
     return { success: true };
   }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('force-subscribe/:userId')
+  async forceSubscribe(
+    @Param('userId') userId: string,
+    @Body() registerFcmDeviceDto: RegisterFcmDeviceDto,
+    @Request() req,
+  ) {
+    if (req.user.id === +userId || req.user.role === 'admin') {
+      await this.pushNotificationService.forceSubscribeUser(
+        +userId,
+        registerFcmDeviceDto,
+      );
+      return { success: true };
+    } else {
+      return { success: false, message: 'Opération non autorisée' };
+    }
+  }
 }


### PR DESCRIPTION
…ter des fonctionnalités de gestion des préférences utilisateur

- Renommer le contrôleur de notifications en 'alert-notifications'
- Ajouter une méthode pour vérifier les préférences de notification des utilisateurs
- Implémenter des vérifications dans le service de notifications pour s'assurer que les utilisateurs acceptent les notifications avant l'envoi
- Mettre à jour le service de transaction pour respecter les préférences de notification des expéditeurs et des destinataires