### PR TITLE
✨ feat(event): Renommer le statut d'invitation de 'REJECTED' à 'DECLI…

### DIFF
--- a/src/event/entities/event.entity.ts
+++ b/src/event/entities/event.entity.ts
@@ -18,7 +18,7 @@ export enum EventStatus {
 export enum InvitationStatus {
   PENDING = 'PENDING',
   ACCEPTED = 'ACCEPTED',
-  REJECTED = 'REJECTED',
+  DECLINED = 'DECLINED',
 }
 
 export interface InvitedPerson {

--- a/src/migrations/1742914199545-CreateGroupeInvitationEntity.ts
+++ b/src/migrations/1742914199545-CreateGroupeInvitationEntity.ts
@@ -18,7 +18,7 @@ export class CreateGroupeInvitationEntity1742914199545
     if (!enumExists[0].exists) {
       // Si l'enum n'existe pas, on le crée avec les valeurs nécessaires pour cette entité
       await queryRunner.query(`
-        CREATE TYPE "invitation_status_enum" AS ENUM ('PENDING', 'ACCEPTED', 'REJECTED')
+        CREATE TYPE "invitation_status_enum" AS ENUM ('PENDING', 'ACCEPTED', 'DECLINED')
       `);
     } else {
       // Si l'enum existe, on vérifie si 'REJECTED' est déjà une valeur possible
@@ -26,7 +26,7 @@ export class CreateGroupeInvitationEntity1742914199545
         SELECT EXISTS (
           SELECT 1 FROM pg_enum 
           WHERE enumtypid = (SELECT oid FROM pg_type WHERE typname = 'invitation_status_enum')
-          AND enumlabel = 'REJECTED'
+          AND enumlabel = 'DECLINED'
         )
       `);
 


### PR DESCRIPTION
…NED' et mettre à jour la migration associée

- Changement du nom du statut d'invitation dans l'entité Event pour une meilleure clarté
- Mise à jour de la migration pour refléter le changement de valeur dans l'enum 'invitation_status_enum'