### PR TITLE
✨ feat(client, invoice): ajout d'un délai de paiement par défaut pour…

### DIFF
--- a/src/clients/entities/client.entity.ts
+++ b/src/clients/entities/client.entity.ts
@@ -58,6 +58,13 @@ export class Client {
   @Column({ default: false })
   is_physical_person: boolean;
 
+  @Column({
+    type: 'int',
+    nullable: true,
+    comment: 'Default payment deadline in days',
+  })
+  default_payment_deadline: number;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/src/invoice/invoice.service.ts
+++ b/src/invoice/invoice.service.ts
@@ -147,6 +147,11 @@ export class InvoiceService {
       invoiceCreated.id,
     );
     invoiceCreated.pdfS3Key = pdfKey;
+    const paymentDeadline = new Date(quoteFromDB.service_date);
+    paymentDeadline.setDate(
+      paymentDeadline.getDate() + quoteFromDB.payment_deadline,
+    );
+    invoiceCreated.payment_deadline = paymentDeadline;
     await this._invoiceRepository.save(invoiceCreated);
 
     this.mailService.sendInvoiceEmail(invoiceCreated, pdfKey);

--- a/src/migrations/1744705413110-AddDefaultPaymentDeadlineToClient.ts
+++ b/src/migrations/1744705413110-AddDefaultPaymentDeadlineToClient.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddDefaultPaymentDeadlineToClient1744705413110
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'client',
+      new TableColumn({
+        name: 'default_payment_deadline',
+        type: 'int',
+        isNullable: true,
+        comment: 'Default payment deadline in days',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('client', 'default_payment_deadline');
+  }
+}


### PR DESCRIPTION
… les clients

- Ajout d'une nouvelle colonne `default_payment_deadline` dans l'entité Client pour définir le délai de paiement par défaut en jours.
- Mise à jour du service Invoice pour calculer la date limite de paiement en fonction du délai de paiement du devis.