### PR TITLE
✨ refactor(entities, migrations): conversion des soldes en type décimal

### DIFF
--- a/src/compte_groupe/entities/compte_groupe.entity.ts
+++ b/src/compte_groupe/entities/compte_groupe.entity.ts
@@ -15,7 +15,7 @@ export class CompteGroupe {
   @Column({ unique: true })
   username: string;
 
-  @Column({ default: 0, type: 'double precision' })
+  @Column({ default: 0, type: 'decimal', precision: 10, scale: 2 })
   solde?: number;
 
   @Column({ default: 1 })

--- a/src/compte_principal/entities/compte_principal.entity.ts
+++ b/src/compte_principal/entities/compte_principal.entity.ts
@@ -25,7 +25,7 @@ export class ComptePrincipal {
   @Column({ unique: true })
   username: string;
 
-  @Column({ default: 0, type: 'double precision' })
+  @Column({ default: 0, type: 'decimal', precision: 10, scale: 2 })
   solde?: number;
 
   @Column({ default: 1 })

--- a/src/migrations/1749999999999-ConvertSoldeToDecimal.ts
+++ b/src/migrations/1749999999999-ConvertSoldeToDecimal.ts
@@ -1,0 +1,121 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ConvertSoldeToDecimal1749999999999 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Conversion pour compte_principal
+    await queryRunner.query(
+      `ALTER TABLE compte_principal ADD COLUMN solde_temp DECIMAL(10,2)`,
+    );
+
+    await queryRunner.query(
+      `UPDATE compte_principal SET solde_temp = CAST(solde AS DECIMAL(10,2))`,
+    );
+
+    await queryRunner.query(`ALTER TABLE compte_principal DROP COLUMN solde`);
+
+    await queryRunner.query(
+      `ALTER TABLE compte_principal RENAME COLUMN solde_temp TO solde`,
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE compte_principal ALTER COLUMN solde SET DEFAULT 0`,
+    );
+
+    // Conversion pour compte_groupe
+    await queryRunner.query(
+      `ALTER TABLE compte_groupe ADD COLUMN solde_temp DECIMAL(10,2)`,
+    );
+
+    await queryRunner.query(
+      `UPDATE compte_groupe SET solde_temp = CAST(solde AS DECIMAL(10,2))`,
+    );
+
+    await queryRunner.query(`ALTER TABLE compte_groupe DROP COLUMN solde`);
+
+    await queryRunner.query(
+      `ALTER TABLE compte_groupe RENAME COLUMN solde_temp TO solde`,
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE compte_groupe ALTER COLUMN solde SET DEFAULT 0`,
+    );
+
+    // Conversion pour transaction (amount)
+    await queryRunner.query(
+      `ALTER TABLE transaction ADD COLUMN amount_temp DECIMAL(10,2)`,
+    );
+
+    await queryRunner.query(
+      `UPDATE transaction SET amount_temp = CAST(amount AS DECIMAL(10,2))`,
+    );
+
+    await queryRunner.query(`ALTER TABLE transaction DROP COLUMN amount`);
+
+    await queryRunner.query(
+      `ALTER TABLE transaction RENAME COLUMN amount_temp TO amount`,
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE transaction ALTER COLUMN amount SET DEFAULT 0`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Réversion pour compte_principal
+    await queryRunner.query(
+      `ALTER TABLE compte_principal ADD COLUMN solde_temp double precision`,
+    );
+
+    await queryRunner.query(
+      `UPDATE compte_principal SET solde_temp = CAST(solde AS double precision)`,
+    );
+
+    await queryRunner.query(`ALTER TABLE compte_principal DROP COLUMN solde`);
+
+    await queryRunner.query(
+      `ALTER TABLE compte_principal RENAME COLUMN solde_temp TO solde`,
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE compte_principal ALTER COLUMN solde SET DEFAULT 0`,
+    );
+
+    // Réversion pour compte_groupe
+    await queryRunner.query(
+      `ALTER TABLE compte_groupe ADD COLUMN solde_temp double precision`,
+    );
+
+    await queryRunner.query(
+      `UPDATE compte_groupe SET solde_temp = CAST(solde AS double precision)`,
+    );
+
+    await queryRunner.query(`ALTER TABLE compte_groupe DROP COLUMN solde`);
+
+    await queryRunner.query(
+      `ALTER TABLE compte_groupe RENAME COLUMN solde_temp TO solde`,
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE compte_groupe ALTER COLUMN solde SET DEFAULT 0`,
+    );
+
+    // Réversion pour transaction (amount)
+    await queryRunner.query(
+      `ALTER TABLE transaction ADD COLUMN amount_temp double precision`,
+    );
+
+    await queryRunner.query(
+      `UPDATE transaction SET amount_temp = CAST(amount AS double precision)`,
+    );
+
+    await queryRunner.query(`ALTER TABLE transaction DROP COLUMN amount`);
+
+    await queryRunner.query(
+      `ALTER TABLE transaction RENAME COLUMN amount_temp TO amount`,
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE transaction ALTER COLUMN amount SET DEFAULT 0`,
+    );
+  }
+}

--- a/src/transaction/entities/transaction.entity.ts
+++ b/src/transaction/entities/transaction.entity.ts
@@ -19,7 +19,7 @@ export class Transaction {
   @Column()
   communication: string;
 
-  @Column({ type: 'double precision', default: 0 })
+  @Column({ type: 'decimal', precision: 10, scale: 2, default: 0 })
   amount: number;
 
   @Column({ nullable: true })


### PR DESCRIPTION
- Mise à jour des entités `CompteGroupe`, `ComptePrincipal` et `Transaction` pour utiliser le type `decimal` avec précision et échelle.
- Ajout d'une migration pour convertir les colonnes `solde` et `amount` existantes en type `decimal(10,2)` dans les tables correspondantes.